### PR TITLE
Fix error when there is no house garage

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -787,7 +787,7 @@ Citizen.CreateThread(function()
         local inGarageRange = false
 
         if HouseGarages ~= nil and currentHouseGarage ~= nil then
-            if hasGarageKey and HouseGarages[currentHouseGarage] ~= nil then
+            if hasGarageKey and HouseGarages[currentHouseGarage] ~= nil and HouseGarages[currentHouseGarage].takeVehicle ~= nil then
                 local takeDist = #(pos - vector3(HouseGarages[currentHouseGarage].takeVehicle.x, HouseGarages[currentHouseGarage].takeVehicle.y, HouseGarages[currentHouseGarage].takeVehicle.z))
                 if takeDist <= 15 then
                     inGarageRange = true


### PR DESCRIPTION
The HouseGarages object gets populated but has `takeVehicle` set as nil when there is no house garage. This check fixes the clientside error when it happens