### PR TITLE
Two bug fixes for house garages

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -445,7 +445,7 @@ function TakeOutGarageVehicle(vehicle)
                 end
 
                 SetVehicleNumberPlateText(veh, vehicle.plate)
-                SetEntityHeading(veh, HouseGarages[currentHouseGarage].takeVehicle.w)
+                SetEntityHeading(veh, HouseGarages[currentHouseGarage].takeVehicle.h)
                 TaskWarpPedIntoVehicle(PlayerPedId(), veh, -1)
                 exports['LegacyFuel']:SetFuel(veh, vehicle.fuel)
                 SetEntityAsMissionEntity(veh, true, true)
@@ -711,7 +711,7 @@ CreateThread(function()
         local ped = PlayerPedId()
         local pos = GetEntityCoords(ped)
         local inGarageRange = false
-        if HouseGarages and currentHouseGarage then
+        if HouseGarages and currentHouseGarage and pos then
             if hasGarageKey and HouseGarages[currentHouseGarage] and HouseGarages[currentHouseGarage].takeVehicle and HouseGarages[currentHouseGarage].takeVehicle.x then
                 local takeDist = #(pos - vector3(HouseGarages[currentHouseGarage].takeVehicle.x, HouseGarages[currentHouseGarage].takeVehicle.y, HouseGarages[currentHouseGarage].takeVehicle.z))
                 if takeDist <= 15 then


### PR DESCRIPTION
Bug 1: House garages always set their vehicle heading to 0 when pulled out of the garage. The reason for this is house garages store their heading in an attribute h, not the attribute w like the other garages.

Bug 2: House garages don't render after a while at all in game. This is because the thread that renders them crashes on because of a nil value when it tries to calculate takeDist in qb-garages/client/main.lua. I assume that this nil value is pos produced from GetEntityCoords because the code is already testing the other possible culprits. This nil value exception crashes the thread I believe which is why house garages stop rendering.

I have not tested this code but I have gathered this from observing behavior in game and looking at the code.