### PR TITLE
Adding NPCs to garages

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,13 +1,14 @@
 AutoRespawn = false --True == auto respawn cars that are outside into your garage on script restart, false == does not put them into your garage and players have to go to the impound
-SharedGarages = false   --True == Gang and job garages are shared, false == Gang and Job garages are personal
+SharedGarages = false --True == Gang and job garages are shared, false == Gang and Job garages are personal
 VisuallyDamageCars = true --True == Visually damage cars that go out of the garage depending of body damage, false == Do not visually damage cars (damage is still applied to car values)
 
 Garages = {
     ["motelgarage"] = {
         label = "Motel Parking",
-        takeVehicle = vector3(273.43, -343.99, 44.91),
+        takeVehicle = vector4(274.15, -344.18, 44.92, 71.43),
         spawnPoint = vector4(270.94, -342.96, 43.97, 161.5),
         putVehicle = vector3(276.69, -339.85, 44.91),
+        npc = "cs_floyd",
         showBlip = true,
         blipName = "Public Parking",
         blipNumber = 357,
@@ -16,7 +17,7 @@ Garages = {
     },
     ["sapcounsel"] = {
         label = "San Andreas Parking",
-        takeVehicle = vector3(-330.01, -780.33, 33.96),
+        takeVehicle = vector4(-329.88, -780.31, 33.96, 37.45),
         spawnPoint = vector4(-334.44, -780.75, 33.96, 137.5),
         putVehicle = vector3(-336.31, -774.93, 33.96),
         showBlip = true,
@@ -27,9 +28,10 @@ Garages = {
     },
     ["spanishave"] = {
         label = "Spanish Ave Parking",
-        takeVehicle = vector3(-1160.86, -741.41, 19.63),
+        takeVehicle = vector4(-1160.53, -741.18, 19.66, 126.3),
         spawnPoint = vector4(-1163.88, -749.32, 18.42, 35.5),
         putVehicle = vector3(-1147.58, -738.11, 19.31),
+        npc = "cs_floyd",
         showBlip = true,
         blipName = "Public Parking",
         blipNumber = 357,
@@ -38,9 +40,10 @@ Garages = {
     },
     ["caears24"] = {
         label = "Caears 24 Parking",
-        takeVehicle = vector3(69.84, 12.6, 68.96),
+        takeVehicle = vector4(69.6, 12.47, 68.96, 249.36),
         spawnPoint = vector4(73.21, 10.72, 68.83, 163.5),
         putVehicle = vector3(65.43, 21.19, 69.47),
+        npc = "cs_floyd",
         showBlip = true,
         blipName = "Public Parking",
         blipNumber = 357,
@@ -49,9 +52,10 @@ Garages = {
     },
     ["caears242"] = {
         label = "Caears 24 Parking",
-        takeVehicle = vector3(-475.31, -818.73, 30.46),
+        takeVehicle = vector4(-475.28, -818.75, 30.47, 286.21),
         spawnPoint = vector4(-472.03, -815.47, 30.5, 177.5),
         putVehicle = vector3(-453.6, -817.08, 30.61),
+        npc = "cs_floyd",
         showBlip = true,
         blipName = "Public Parking",
         blipNumber = 357,
@@ -60,9 +64,10 @@ Garages = {
     },
     ["lagunapi"] = {
         label = "Laguna Parking",
-        takeVehicle = vector3(364.37, 297.83, 103.49),
+        takeVehicle = vector4(363.84, 297.94, 103.5, 244.81),
         spawnPoint = vector4(367.49, 297.71, 103.43, 340.5),
         putVehicle = vector3(363.04, 283.51, 103.38),
+        npc = "cs_floyd",
         showBlip = true,
         blipName = "Public Parking",
         blipNumber = 357,
@@ -71,9 +76,10 @@ Garages = {
     },
     ["airportp"] = {
         label = "Airport Parking",
-        takeVehicle = vector3(-796.86, -2024.85, 8.88),
+        takeVehicle = vector4(-796.0, -2023.29, 9.17, 334.05),
         spawnPoint = vector4(-800.41, -2016.53, 9.32, 48.5),
         putVehicle = vector3(-804.84, -2023.21, 9.16),
+        npc = "cs_floyd",
         showBlip = true,
         blipName = "Public Parking",
         blipNumber = 357,
@@ -82,9 +88,10 @@ Garages = {
     },
     ["beachp"] = {
         label = "Beach Parking",
-        takeVehicle = vector3(-1183.1, -1511.11, 4.36),
+        takeVehicle = vector4(-1183.31, -1510.87, 4.37, 212.99),
         spawnPoint = vector4(-1181.0, -1505.98, 4.37, 214.5),
         putVehicle = vector3(-1176.81, -1498.63, 4.37),
+        npc = "cs_floyd",
         showBlip = true,
         blipName = "Public Parking",
         blipNumber = 357,
@@ -93,9 +100,10 @@ Garages = {
     },
     ["themotorhotel"] = {
         label = "The Motor Hotel Parking",
-        takeVehicle = vector3(1137.77, 2663.54, 37.9),
+        takeVehicle = vector4(1141.83, 2662.15, 38.16, 89.84),
         spawnPoint = vector4(1137.69, 2673.61, 37.9, 359.5),
         putVehicle = vector3(1137.75, 2652.95, 37.9),
+        npc = "a_m_m_farmer_01",
         showBlip = true,
         blipName = "Public Parking",
         blipNumber = 357,
@@ -104,9 +112,10 @@ Garages = {
     },
     ["liqourparking"] = {
         label = "Liqour Parking",
-        takeVehicle = vector3(934.95, 3606.59, 32.81),
-        spawnPoint = vector4(941.57, 3619.99, 32.5, 141.5),
-        putVehicle = vector3(939.37, 3612.25, 32.69),
+        takeVehicle = vector4(959.2, 3619.0, 32.67, 86.38),
+        spawnPoint = vector4(951.74, 3615.42, 32.21, 91.31),
+        putVehicle = vector3(951.31, 3622.7, 32.42),
+        npc = "cs_russiandrunk",
         showBlip = true,
         blipName = "Public Parking",
         blipNumber = 357,
@@ -115,9 +124,10 @@ Garages = {
     },
     ["shoreparking"] = {
         label = "Shore Parking",
-        takeVehicle = vector3(1726.21, 3707.16, 34.17),
+        takeVehicle = vector4(1737.55, 3710.37, 34.14, 15.74),
         spawnPoint = vector4(1730.31, 3711.07, 34.2, 20.5),
         putVehicle = vector3(1737.13, 3718.91, 34.04),
+        npc = "cs_floyd",
         showBlip = true,
         blipName = "Public Parking",
         blipNumber = 357,
@@ -126,9 +136,10 @@ Garages = {
     },
     ["haanparking"] = {
         label = "Bell Farms Parking",
-        takeVehicle = vector3(78.34, 6418.74, 31.28),
+        takeVehicle = vector4(83.99, 6420.67, 31.76, 130.86),
         spawnPoint = vector4(70.71, 6425.16, 30.92, 68.5),
         putVehicle = vector3(85.3, 6427.52, 31.33),
+        npc = "cs_floyd",
         showBlip = true,
         blipName = "Public Parking",
         blipNumber = 357,
@@ -137,9 +148,10 @@ Garages = {
     },
     ["dumbogarage"] = {
         label = "Dumbo Private Parking",
-        takeVehicle = vector3(157.26, -3240.00, 7.00),
+        takeVehicle = vector4(156.57, -3239.96, 7.03, 273.16),
         spawnPoint = vector4(165.32, -3236.10, 5.93, 268.5),
         putVehicle = vector3(165.32, -3230.00, 5.93),
+        npc = "cs_floyd",
         showBlip = true,
         blipName = "Public Parking",
         blipNumber = 357,
@@ -148,9 +160,10 @@ Garages = {
     },
     ["pillboxgarage"] = {
         label = "Pillbox Garage Parking",
-        takeVehicle = vector3(215.9499, -809.698, 30.731),
+        takeVehicle = vector4(215.45, -809.98, 30.74, 256.52),
         spawnPoint = vector4(234.1942, -787.066, 30.193, 159.6),
         putVehicle = vector3(218.0894, -781.370, 30.389),
+        npc = "cs_floyd",
         showBlip = true,
         blipName = "Public Parking",
         blipNumber = 357,
@@ -169,8 +182,9 @@ Garages = {
     --},
     ["impoundlot"] = {
         label = "Impound Lot",
-        takeVehicle = vector3(409.89, -1623.51, 29.29),
+        takeVehicle = vector4(409.64, -1623.43, 29.29, 225.92),
         spawnPoint = vector4(407.92, -1646.29, 29.29, 226.39),
+        npc = "cs_prolsec_02",
         showBlip = true,
         blipName = "Impound Lot",
         blipNumber = 68,
@@ -179,7 +193,7 @@ Garages = {
     },
     ["ballas"] = {
         label = "Ballas",
-        takeVehicle = vector3(98.50, -1954.49, 20.84),
+        takeVehicle = vector4(98.38, -1954.43, 20.75, 346.05),
         spawnPoint = vector4(98.50, -1954.49, 20.75, 335.73),
         putVehicle = vector3(94.75, -1959.93, 20.84),
         showBlip = false,
@@ -191,7 +205,7 @@ Garages = {
     },
     ["families"] = {
         label = "La Familia",
-        takeVehicle = vector3(-811.65, 187.49, 72.48),
+        takeVehicle = vector4(-811.51, 187.55, 72.48, 99.81),
         spawnPoint = vector4(-818.43, 184.97, 72.28, 107.85),
         putVehicle = vector3(-811.65, 187.49, 72.48),
         showBlip = false,
@@ -203,7 +217,7 @@ Garages = {
     },
     ["lostmc"] = {
         label = "Lost MC",
-        takeVehicle = vector3(957.25, -129.63, 74.39),
+        takeVehicle = vector4(955.8, -128.81, 74.39, 263.86),
         spawnPoint = vector4(957.25, -129.63, 74.39, 199.21),
         putVehicle = vector3(950.47, -122.05, 74.36),
         showBlip = false,
@@ -215,7 +229,7 @@ Garages = {
     },
     ["cartel"] = {
         label = "Cartel",
-        takeVehicle = vector3(1407.18, 1118.04, 114.84),
+        takeVehicle = vector4(1407.37, 1118.02, 114.84, 263.86),
         spawnPoint = vector4(1407.18, 1118.04, 114.84, 88.34),
         putVehicle = vector3(1407.18, 1118.04, 114.84),
         showBlip = false,
@@ -227,7 +241,7 @@ Garages = {
     },
     ["police"] = {
         label = "Police",
-        takeVehicle = vector3(454.6, -1017.4, 28.4),
+        takeVehicle = vector4(454.67, -1017.36, 28.43, 90.82),
         spawnPoint = vector4(438.4, -1018.3, 27.7, 90.0),
         putVehicle = vector3(452.88, -1006.98, 27.5),
         showBlip = false,
@@ -239,9 +253,10 @@ Garages = {
     },
     ["intairport"] = {
         label = "Airport Hangar",
-        takeVehicle = vector3(-1025.92, -3017.86, 13.95),
+        takeVehicle = vector4(-1026.0, -3018.24, 13.95, 354.66),
         spawnPoint = vector4(-979.2, -2995.51, 13.95, 52.19),
         putVehicle = vector3(-1003.38, -3008.87, 13.95),
+        npc = "s_m_m_pilot_02",
         showBlip = true,
         blipName = "Hangar",
         blipNumber = 360,
@@ -250,9 +265,10 @@ Garages = {
     },
     ["higginsheli"] = {
         label = "Higgins Helitours",
-        takeVehicle = vector3(-722.15, -1472.79, 5.0),
+        takeVehicle = vector4(-722.06, -1472.62, 5.0, 52.68),
         spawnPoint = vector4(-724.83, -1443.89, 5.0, 140.1),
         putVehicle = vector3(-745.48, -1468.46, 5.0),
+        npc = "s_m_m_pilot_02",
         showBlip = true,
         blipName = "Hangar",
         blipNumber = 360,
@@ -261,9 +277,10 @@ Garages = {
     },
     ["airsshores"] = {
         label = "Sandy Shores Hangar",
-        takeVehicle = vector3(1758.19, 3296.66, 41.14),
+        takeVehicle = vector4(1758.41, 3297.44, 41.15, 148.13),
         spawnPoint = vector4(1740.98, 3279.08, 41.75, 106.77),
         putVehicle = vector3(1740.4, 3283.92, 41.1),
+        npc = "a_m_m_hillbilly_01",
         showBlip = true,
         blipName = "Hangar",
         blipNumber = 360,
@@ -272,8 +289,9 @@ Garages = {
     },
     ["airdepot"] = {
         label = "Air Depot",
-        takeVehicle = vector3(-1243.29, -3392.3, 13.94),
+        takeVehicle = vector4(-1243.31, -3392.37, 13.94, 45.22),
         spawnPoint = vector4(-1269.67, -3377.74, 13.94, 327.88),
+        npc = "s_m_m_pilot_02",
         showBlip = true,
         blipName = "Air Depot",
         blipNumber = 359,
@@ -282,7 +300,7 @@ Garages = {
     },
     ["lsymc"] = {
         label = "LSYMC Boathouse",
-        takeVehicle = vector3(-794.66, -1510.83, 1.59),
+        takeVehicle = vector4(-794.79, -1510.76, 1.6, 283.98),
         spawnPoint = vector4(-793.58, -1501.4, 0.12, 111.5),
         putVehicle = vector3(-793.58, -1501.4, 0.12),
         showBlip = true,
@@ -293,7 +311,7 @@ Garages = {
     },
     ["paleto"] = {
         label = "Paleto Boathouse",
-        takeVehicle = vector3(-277.46, 6637.2, 7.48),
+        takeVehicle = vector4(-277.41, 6637.23, 7.5, 219.59),
         spawnPoint = vector4(-289.2, 6637.96, 1.01, 45.5),
         putVehicle = vector3(-289.2, 6637.96, 1.01),
         showBlip = true,
@@ -304,7 +322,7 @@ Garages = {
     },
     ["millars"] = {
         label = "Millars Boathouse",
-        takeVehicle = vector3(1299.24, 4216.69, 33.9),
+        takeVehicle = vector4(1299.4, 4216.46, 33.91, 349.31),
         spawnPoint = vector4(1297.82, 4209.61, 30.12, 253.5),
         putVehicle = vector3(1297.82, 4209.61, 30.12),
         showBlip = true,
@@ -315,9 +333,10 @@ Garages = {
     },
     ["seadepot"] = {
         label = "LSYMC Depot",
-        takeVehicle = vector3(-772.98, -1430.76, 1.59),
+        takeVehicle = vector4(-773.44, -1430.53, 1.6, 230.59),
         spawnPoint = vector4(-729.77, -1355.49, 1.19, 142.5),
         putVehicle = vector3(-729.77, -1355.49, 1.19),
+        npc = "cs_prolsec_02",
         showBlip = true,
         blipName = "LSYMC Depot",
         blipNumber = 356,

--- a/server/main.lua
+++ b/server/main.lua
@@ -234,8 +234,6 @@ RegisterNetEvent('qb-garage:server:PayDepotPrice', function(data)
     end)
 end)
 
-
-
 --External Calls
 --Call from qb-vehiclesales
 QBCore.Functions.CreateCallback("qb-garage:server:checkVehicleOwner", function(source, cb, plate)


### PR DESCRIPTION
This PR adds clientside NPCs to garages. When leaving the area (takeDist >= 85) it will free up NPC memory.

NPCs can be added to garages via the attribute `npc="ped_name"` and will spawn on the `takeVehicle` coordinates.
Therefore all the `takeVehicle` coordinates where updated to `vector4`.