### PR TITLE
Removing Police impounded cars from regular depot

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -13,7 +13,7 @@ QBCore.Functions.CreateCallback("qb-garage:server:GetGarageVehicles", function(s
             end
         end)
     elseif type == "depot" then    --Depot give player cars that are not in garage only
-        MySQL.Async.fetchAll('SELECT * FROM player_vehicles WHERE citizenid = ? AND (state = ? OR state = ?)', {pData.PlayerData.citizenid, 0, 2}, function(result)
+        MySQL.Async.fetchAll('SELECT * FROM player_vehicles WHERE citizenid = ? AND state = ?', {pData.PlayerData.citizenid, 0}, function(result) 
             local tosend = {}
             if result[1] then
                 --Check vehicle type against depot type


### PR DESCRIPTION
Line 16 written below if I understand it correctly allows persons to remove police impounded vehicles from the depot
        MySQL.Async.fetchAll('SELECT * FROM player_vehicles WHERE citizenid = ? AND (state = ? OR state = ?)', {pData.PlayerData.citizenid, 0, 2}, function(result)
Changing it to the line below removes the option and citizens will have to go to the police to get their cars back
        MySQL.Async.fetchAll('SELECT * FROM player_vehicles WHERE citizenid = ? AND state = ?', {pData.PlayerData.citizenid, 0}, function(result)

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Does your code fit the style guidelines? [yes/no]
- Does your PR fit the contribution guidelines? [yes/no]
