### PR TITLE
Server side car spawning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 ![image](https://user-images.githubusercontent.com/82112471/149678977-2a574ee9-8ecc-494f-a845-e17281a74594.png)
 
-
+**Server side car spawn**
+* With the option ServerSpawnCars car can be spawned from the server, making them existing at any time as long the server is not restart
 
 **House Garages**
 * Park owned cars in house garages. To add a house garage, you must have the realestate job and do /addgarage.

--- a/client/main.lua
+++ b/client/main.lua
@@ -336,7 +336,7 @@ RegisterNetEvent("qb-garage:client:VehicleList", function(data)
     end, indexgarage, type, garage.vehicle)
 end)
 
-local function SetProperties(veh, props, heading, index, owner)
+local function SetProperties(veh, props, heading, owner)
     QBCore.Functions.TriggerCallback('qb-garage:server:GetVehicleProperties', function(properties)
         if props.plate then
             SetNetworkIdAlwaysExistsForPlayer(NetworkGetNetworkIdFromEntity(veh), PlayerPedId(), true)
@@ -361,7 +361,7 @@ local function SetProperties(veh, props, heading, index, owner)
 
 end
 
-RegisterNetEvent('qb-garage:client:SetProperties', function(netId, vehicle, heading, index, owner)
+RegisterNetEvent('qb-garage:client:SetProperties', function(netId, vehicle, heading, owner)
     if not NetworkDoesEntityExistWithNetworkId(netId) then
         print("Vehicle not found")
         -- vehicles wont instantly exist on the client, even though they exist on the server.
@@ -370,7 +370,7 @@ RegisterNetEvent('qb-garage:client:SetProperties', function(netId, vehicle, head
     if NetworkDoesEntityExistWithNetworkId(netId) then
         print("Found id : ".. netId .. "applying props")
         local veh = NetworkGetEntityFromNetworkId(netId)
-        SetProperties(veh, vehicle, heading, index, owner)
+        SetProperties(veh, vehicle, heading, owner)
     else
         print("Could not find id : ".. netId)
     end
@@ -397,7 +397,7 @@ RegisterNetEvent('qb-garage:client:takeOutGarage', function(data)
             if not ServerSpawnCars then
                 QBCore.Functions.SpawnVehicle(vehicle.vehicle, function(veh)
                     TriggerEvent("vehiclekeys:client:SetOwner", vehicle.plate)
-                    SetProperties(veh, vehicle, heading, index)
+                    SetProperties(veh, vehicle, heading)
                     TriggerServerEvent('qb-garage:server:updateVehicleState', 0, vehicle.plate, index)
                     closeMenuFull()
                     if type == "house" then
@@ -420,12 +420,12 @@ RegisterNetEvent('qb-garage:client:takeOutGarage', function(data)
                 --    Wait(50)
                 --end
                 --local veh = NetworkGetEntityFromNetworkId(spawn)
-                --SetProperties(veh, vehicle, heading, index)
+                --SetProperties(veh, vehicle, heading)
             end
         else
             QBCore.Functions.Notify(Lang:t("error.not_impound"), "error", 5000)
         end
-    end, vehicle.plate, type, vehicle, location, heading, index)
+    end, vehicle.plate, type, vehicle, location, heading)
 end)
 
 local function enterVehicle(veh, indexgarage, type, garage)

--- a/config.lua
+++ b/config.lua
@@ -1,6 +1,7 @@
-AutoRespawn = false --True == auto respawn cars that are outside into your garage on script restart, false == does not put them into your garage and players have to go to the impound
-SharedGarages = false   --True == Gang and job garages are shared, false == Gang and Job garages are personal
-VisuallyDamageCars = true --True == Visually damage cars that go out of the garage depending of body damage, false == Do not visually damage cars (damage is still applied to car values)
+AutoRespawn = false         --True == auto respawn cars that are outside into your garage on script restart, false == does not put them into your garage and players have to go to the impound
+SharedGarages = true        --True == Gang and job garages are shared, false == Gang and Job garages are personal
+VisuallyDamageCars = true   --True == Visually damage cars that go out of the garage depending of body damage, false == Do not visually damage cars (damage is still applied to car values)
+ServerSpawnCars = true      --True == Server spawns cars, false == Clients spawn cars
 
 Garages = {
     ["motelgarage"] = {

--- a/server/main.lua
+++ b/server/main.lua
@@ -149,9 +149,9 @@ QBCore.Functions.CreateCallback("qb-garage:server:GetVehicleProperties", functio
     cb(properties)
 end)
 
-QBCore.Functions.CreateCallback("qb-garage:server:IsSpawnOk", function(source, cb, plate, type, vehicle, position, heading, index)
+QBCore.Functions.CreateCallback("qb-garage:server:IsSpawnOk", function(source, cb, plate, type, vehicle, position, heading)
     local model = vehicle.vehicle
-    local ok = false
+    local ok
     if type == "depot" then         --If depot, check if vehicle is not already spawned on the map
         if OutsideVehicles[plate] and DoesEntityExist(OutsideVehicles[plate].entity) then
             ok = false
@@ -173,7 +173,7 @@ QBCore.Functions.CreateCallback("qb-garage:server:IsSpawnOk", function(source, c
             end
             if DoesEntityExist(veh) then
                 netId = NetworkGetNetworkIdFromEntity(veh)
-                TriggerClientEvent("qb-garage:client:SetProperties", -1, netId, vehicle, heading, index, source)
+                TriggerClientEvent("qb-garage:client:SetProperties", -1, netId, vehicle, heading, source)
                 cb(true)
             else
                 cb(false)


### PR DESCRIPTION
New option ServerSpawnCars in config
When true the car is spawn from the server and not from the client anymore, making the car persistent between server restart
Cars doesn't despawn anymore when player dropped or too far away. Damage is also kept

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Does your code fit the style guidelines? [yes/no]
- Does your PR fit the contribution guidelines? [yes/no]
