### PR TITLE
Fix the duplicating of blips and zones

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -11,6 +11,7 @@ local currentGarage = nil
 local currentGarageIndex = nil
 local garageZones = {}
 local lasthouse = nil
+local blipsZonesLoaded = false
 
 
 --Menus
@@ -415,6 +416,8 @@ local function enterVehicle(veh, indexgarage, type, garage)
 end
 
 local function CreateBlipsZones()
+    if blipsZonesLoaded then return end
+
     PlayerData = QBCore.Functions.GetPlayerData()
     PlayerGang = PlayerData.gang
     PlayerJob = PlayerData.job
@@ -442,6 +445,7 @@ local function CreateBlipsZones()
             CreateZone("marker", garage, index)
         end
     end
+    blipsZonesLoaded = true
 end
 
 RegisterNetEvent('qb-garages:client:setHouseGarage', function(house, hasKey)
@@ -470,7 +474,8 @@ AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
     CreateBlipsZones()
 end)
 
-AddEventHandler("onResourceStart", function()
+AddEventHandler("onResourceStart", function(res)
+    if res ~= GetCurrentResourceName() then return end
     CreateBlipsZones()
 end)
 


### PR DESCRIPTION
**Describe Pull request**
This fixes the issue of blips and zones duplicating whenever any resource is (re)started after qb-garages, this is because of the missing check of resource name but I added an extra to make sure.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
