### PR TITLE
fix(client): Handle house garage heading changing from h to w

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -96,13 +96,13 @@ local function CreateZone(type, garage, index)
     elseif type == 'hmarker' then
         size = 20
         coords = vector3(garage.takeVehicle.x, garage.takeVehicle.y, garage.takeVehicle.z)
-        heading = 0
+        heading = garage.takeVehicle.w
         minz = coords.z - 4.0
         maxz = coords.z + 2.0
     elseif type == 'house' then
         size = 2
         coords = vector3(garage.takeVehicle.x, garage.takeVehicle.y, garage.takeVehicle.z)
-        heading = 0
+        heading = garage.takeVehicle.w
         minz = coords.z - 1.0
         maxz = coords.z + 2.0
     end

--- a/client/main.lua
+++ b/client/main.lua
@@ -347,6 +347,7 @@ RegisterNetEvent('qb-garages:client:takeOutGarage', function(data)
         if spawn then
             local location
             if type == "house" then
+                if garage.takeVehicle.h then garage.takeVehicle.w = garage.takeVehicle.h end
                 location = garage.takeVehicle
             else
                 location = garage.spawnPoint

--- a/client/main.lua
+++ b/client/main.lua
@@ -347,7 +347,7 @@ RegisterNetEvent('qb-garages:client:takeOutGarage', function(data)
         if spawn then
             local location
             if type == "house" then
-                if garage.takeVehicle.h then garage.takeVehicle.w = garage.takeVehicle.h end
+                if garage.takeVehicle.h then garage.takeVehicle.w = garage.takeVehicle.h end -- backward compatibility
                 location = garage.takeVehicle
             else
                 location = garage.spawnPoint


### PR DESCRIPTION
**Describe Pull request**
This PR handles changing the house garage heading from `h` to `w` in the database. It also provides backward compatibilty for existing garages meaning the user does not have to manually update their database.

Fixes #261 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
