### PR TITLE
fix(markers): Crash on nil `putVehicle`

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -486,7 +486,9 @@ CreateThread(function()
         sleep = 2000
         if currentGarage ~= nil then
             if Markers then
-                DrawMarker(2, currentGarage.putVehicle.x, currentGarage.putVehicle.y, currentGarage.putVehicle.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 255, 255, 255, 255, false, false, false, true, false, false, false)
+                if currentGarage.putVehicle then
+                    DrawMarker(2, currentGarage.putVehicle.x, currentGarage.putVehicle.y, currentGarage.putVehicle.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 255, 255, 255, 255, false, false, false, true, false, false, false)
+                end
                 DrawMarker(2, currentGarage.takeVehicle.x, currentGarage.takeVehicle.y, currentGarage.takeVehicle.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 200, 0, 0, 222, false, false, false, true, false, false, false)
                 sleep = 0
             elseif HouseMarkers then


### PR DESCRIPTION
Resolves issue: #290 
Script crashes due to depots having no `putVehicle` value.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**

- [x] Have you personally loaded this code into an updated qbcore project and checked all it's functionality?
- [x] Does your code fit the style guidelines? 
- [x] Does your PR fit the contribution guidelines?
