### PR TITLE
Bugfix for single vehicle in garage

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -75,11 +75,11 @@ QBCore.Functions.CreateCallback('qb-garages:server:GetGarageVehicles', function(
     local vehicles
 
     if type == 'depot' then
-        vehicles = MySQL.prepare.await('SELECT * FROM player_vehicles WHERE citizenid = ? AND depotprice > 0', { citizenId })
+        vehicles = MySQL.rawExecute.await('SELECT * FROM player_vehicles WHERE citizenid = ? AND depotprice > 0', { citizenId })
     elseif Config.SharedGarages then
-        vehicles = MySQL.prepare.await('SELECT * FROM player_vehicles WHERE citizenid = ?', { citizenId })
+        vehicles = MySQL.rawExecute.await('SELECT * FROM player_vehicles WHERE citizenid = ?', { citizenId })
     else
-        vehicles = MySQL.prepare.await('SELECT * FROM player_vehicles WHERE citizenid = ? AND garage = ?', { citizenId, garage })
+        vehicles = MySQL.rawExecute.await('SELECT * FROM player_vehicles WHERE citizenid = ? AND garage = ?', { citizenId, garage })
     end
     if not vehicles then
         cb(nil)

--- a/server/main.lua
+++ b/server/main.lua
@@ -99,7 +99,7 @@ QBCore.Functions.CreateCallback('qb-garages:server:spawnvehicle', function(sourc
     SetEntityHeading(veh, coords.w)
     SetVehicleNumberPlateText(veh, plate)
     local vehProps = {}
-    local result = MySQL.prepare.await('SELECT mods FROM player_vehicles WHERE plate = ?', { plate })
+    local result = MySQL.rawExecute.await('SELECT mods FROM player_vehicles WHERE plate = ?', { plate })
     if result and result[1] then vehProps = json.decode(result[1].mods) end
     local netId = NetworkGetNetworkIdFromEntity(veh)
     OutsideVehicles[plate] = { netID = netId, entity = veh }


### PR DESCRIPTION
**Describe Pull request**
When pulling out a car when there is only one vehicle in that garage, the menu won't open because the SQL doesn't return a table of results as there is only one.

This fixes the issue mentioned: https://github.com/qbcore-framework/qb-garages/issues/304

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
