### PR TITLE
fix(cb): CB returns 1 vehicle

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -220,7 +220,7 @@ QBCore.Functions.CreateCallback('qb-garages:server:GetPlayerVehicles', function(
                     fullname = VehicleData and VehicleData['name'] or 'Unknown Vehicle'
                 end
 
-                Vehicles[#Vehicles] = {
+                Vehicles[#Vehicles + 1] = {
                     fullname = fullname,
                     brand = VehicleData and VehicleData['brand'] or '',
                     model = VehicleData and VehicleData['name'] or '',


### PR DESCRIPTION
**Describe Pull request**
Each vehicle was previously overwriting the first vehicle, resulting in only the last vehicle result being sent to the CB

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [x] (Be honest)
- Does your code fit the style guidelines? [x]
- Does your PR fit the contribution guidelines? [x]
