### PR TITLE
Auto Impound

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -8,6 +8,8 @@ AddEventHandler('onResourceStart', function(resource)
         Wait(100)
         if Config['AutoRespawn'] then
             MySQL.update('UPDATE player_vehicles SET state = 1 WHERE state = 0', {})
+        else
+            MySQL.update('UPDATE player_vehicles SET depotprice = 500 WHERE state = 0', {})
         end
     end
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -189,9 +189,8 @@ RegisterNetEvent('qb-garages:server:PayDepotPrice', function(data)
     local Player = QBCore.Functions.GetPlayer(src)
     local cashBalance = Player.PlayerData.money['cash']
     local bankBalance = Player.PlayerData.money['bank']
-    MySQL.scalar('SELECT depotprice FROM player_vehicles WHERE plate = ?', { data.plate }, function(result)
-        if result then
-            local depotPrice = result[1].depotprice
+    MySQL.scalar('SELECT depotprice FROM player_vehicles WHERE plate = ?', { data.plate }, function(depotPrice)
+        if depotPrice then
 
             if cashBalance >= depotPrice then
                 Player.Functions.RemoveMoney('cash', depotPrice, 'paid-depot')


### PR DESCRIPTION
Automatically sends cars to impound on server restart. If you turn off the feature for the resource to send the cars to the garage on restart the cars are unaccessable. This automatically puts them in impound for 500.

**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
