### PR TITLE
added useZ for CreateHouseZone

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -318,6 +318,7 @@ local function CreateHouseZone(index, garage, zoneType)
     local houseZone = CircleZone:Create(garage.takeVehicle, 5.0, {
         name = zoneType .. '_' .. index,
         debugPoly = false,
+        useZ = true,
         data = {
             indexgarage = index,
             type = zoneType,


### PR DESCRIPTION
I included the useZ parameter because typically, beneath that house Garage, there exists a shell from qb-houses. By utilizing useZ, the PolyZone is constrained in terms of height, limiting it to the actual radius of the underlying circle.