### PR TITLE
Fix: Add failsafe for old default DB value

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -400,7 +400,7 @@ RegisterNetEvent('qb-garages:client:setHouseGarage', function(house, hasKey) -- 
                 houseName = house,
                 takeVehicle = vector3(garageCoords.x, garageCoords.y, garageCoords.z),
                 spawnPoint = {
-                    vector4(garageCoords.x, garageCoords.y, garageCoords.z, garageCoords.w)
+                    vector4(garageCoords.x, garageCoords.y, garageCoords.z, garageCoords.w or garageCoords.h)
                 },
                 label = garageInfo.label,
                 type = 'house',


### PR DESCRIPTION
**Describe Pull request**
This commit will implement a failsafe for if the database is reading "h" for the house garage heading value which was set as a default value by qb-houses in the SQL file. Setting a house garage in qb-houses stores it as "w" instead, in which this commit acts as a fix for data stored previously using "h".

Fixes issue: https://github.com/qbcore-framework/qb-garages/issues/341

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
