### PR TITLE
Fix: Use table length to check for vehicles

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -88,7 +88,7 @@ QBCore.Functions.CreateCallback('qb-garages:server:GetGarageVehicles', function(
     else
         vehicles = MySQL.rawExecute.await('SELECT * FROM player_vehicles WHERE citizenid = ? AND garage = ?', { citizenId, garage })
     end
-    if not vehicles then
+    if #vehicles == 0 then
         cb(nil)
         return
     end


### PR DESCRIPTION
**Describe Pull request**
This PR changes the `not` which checks for false/nil to instead check the table length. This is because oxmysql returns an empty table if a query returns no rows.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
