### PR TITLE
:bug: fix police impound duping issue by restoring "GetVehicleProperties" event

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -133,6 +133,15 @@ QBCore.Functions.CreateCallback('qb-garages:server:spawnvehicle', function(sourc
     cb(netId, vehProps, plate)
 end)
 
+QBCore.Functions.CreateCallback("qb-garage:server:GetVehicleProperties", function(_, cb, plate)
+    local properties = {}
+    local result = MySQL.query.await('SELECT mods FROM player_vehicles WHERE plate = ?', {plate})
+    if result[1] then
+        properties = json.decode(result[1].mods)
+    end
+    cb(properties)
+end)
+
 -- Checks if a vehicle can be spawned based on its type and location.
 QBCore.Functions.CreateCallback('qb-garages:server:IsSpawnOk', function(_, cb, plate, type)
     if OutsideVehicles[plate] and DoesEntityExist(OutsideVehicles[plate].entity) then


### PR DESCRIPTION
**Describe Pull request**
qb-policejob in its current state has an issue with impounded vehicles where, when attempting to pull a vehicle out of the impound, a duplicated car is created and the database is not updated to reflect the intended changes. This is because an event from qb-garages was removed, possibly in error. This commit restores the event.

**Questions (please complete the following information):**
- I have loaded this into a fresh QBCore install with the latest commits and found that it resolves the issue
- the code is copied from older code so it fits the style guidelines
- my PR fits the contribution guidelines
