### PR TITLE
House garage console error fix

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -395,6 +395,7 @@ RegisterNetEvent('qb-garages:client:setHouseGarage', function(house, hasKey) -- 
         end
     else
         QBCore.Functions.TriggerCallback('qb-garages:server:getHouseGarage', function(garageInfo) -- create garage if not exist
+            if not garageInfo.garage then return end
             local garageCoords = json.decode(garageInfo.garage)
             Config.Garages[formattedHouseName] = {
                 houseName = house,


### PR DESCRIPTION
This is fix for console error of non new created house without garages

This error occres when player load into server and any house created in house job but not added garage for this house that time garage script throws error in f8 console for nil value.
![image](https://github.com/qbcore-framework/qb-garages/assets/54040750/c4a68932-5e04-4ebd-8774-6630b9b41048)
