### PR TITLE
feat(remove key on vehicle stored)

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -14,6 +14,7 @@ local function CheckPlayers(vehicle)
             TaskLeaveVehicle(seat, vehicle, 0)
         end
     end
+    TriggerEvent('qb-vehiclekeys:client:RemoveKeys', QBCore.Functions.GetPlate(vehicle))
     Wait(1500)
     QBCore.Functions.DeleteVehicle(vehicle)
 end


### PR DESCRIPTION
**Describe Pull request**
I noticed the event exists but is not being used. It doesn't update on the server side, so based on some other client-side events, I assume this is the intended method of use?

If your PR is to fix an issue mention that issue here
This isn't exactly a fix, but it makes use of some lesser-known recipe features from qb-core. It also allows third-party key systems to attach to an event for qb-garages, further enhancing the user experience.

Since this isn't updating the server-side table, I'm unsure if it fully aligns with the guidelines. Additionally, certain qb-vehiclekeys grant events on the client side also fail to update the server-side table, leading to inconsistency in the preferred method for granting/removing.

I'm happy to make adjustments; I just wanted to understand the plan for these events.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [idk]
