### PR TITLE
fix(client): refresh QBCore on UpdateObject

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -7,6 +7,13 @@ local listenForKey = false
 
 -- Functions
 
+RegisterNetEvent('QBCore:Client:UpdateObject', function()
+    QBCore = exports['qb-core']:GetCoreObject()
+    PlayerData = QBCore.Functions.GetPlayerData()
+    PlayerGang = PlayerData.gang
+    PlayerJob = PlayerData.job
+end)
+
 local function CheckPlayers(vehicle)
     for i = -1, 5, 1 do
         local seat = GetPedInVehicleSeat(vehicle, i)


### PR DESCRIPTION
**Describe Pull request**
Fix: Refresh cached QBCore object and player data when QBCore:Client:UpdateObject is triggered. This prevents qb-garages UI from using stale shared vehicle metadata (e.g. updated name/brand) after qb-core/shared tables are updated at runtime.

If your PR is to fix an issue mention that issue here
N/A

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
